### PR TITLE
Failing unit test demonstrating undefined 'getState' in transition hooks

### DIFF
--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -123,6 +123,26 @@ describe('<ReduxRouter>', () => {
     expect(child.props.location.pathname).to.equal('/parent/child/321');
   });
 
+  it('provides access to `getState` in transition hooks', () => {
+    function createRouteWithTransitionHooks() {
+      const reducer = combineReducers({
+        router: routerStateReducer
+      });
+
+      const history = createHistory();
+      const getRoutes = ({ getState }) => {
+        return (<Route path="/" component={App} onEnter={getState} />);
+      }
+
+      const store = reduxReactRouter({
+        getRoutes, history
+      })(createStore)(reducer);
+    }
+
+    expect(createRouteWithTransitionHooks).to.not.throw(Error);
+  });
+
+
   describe('server-side rendering', () => {
     it('works', () => {
       const reducer = combineReducers({


### PR DESCRIPTION
Failing test case to demonstrate that `getState` throw as error when evaluated in the context of an `onEnter` transition hook.